### PR TITLE
chore: ignore .flux directory

### DIFF
--- a/.flux/.gitignore
+++ b/.flux/.gitignore
@@ -1,5 +1,0 @@
-# Data files (synced via flux-data branch)
-data.json
-data.sqlite
-*.sqlite
-*.db

--- a/.flux/config.json
+++ b/.flux/config.json
@@ -1,5 +1,0 @@
-{
-  "server": "https://app.getflux.dev",
-  "apiKey": "$FLUX_API_KEY",
-  "project": "vjfc2y2"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist-ssr
 packages/data/flux.sqlite*
 packages/data/flux.json
 .env.local
+.flux/


### PR DESCRIPTION
## Summary
- Add `.flux/` to .gitignore
- Remove tracked .flux config files

Prevents dogfooding config from polluting forks.