### PR TITLE
fix: add github_token for fork PR reviews

### DIFF
--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -61,6 +61,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-opus-4-5-20251101
           timeout_minutes: 30
           track_progress: true


### PR DESCRIPTION
Fork PRs can't use OIDC tokens (GitHub security). Explicitly pass github_token to claude-code-action.