### PR TITLE
fix(ci): update claude-code-action to v1

### DIFF
--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -58,13 +58,11 @@ jobs:
           fi
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-5-20251101
           timeout_minutes: 30
-          track_progress: true
           prompt: |
             Review this Pull Request using the standards in .claude/agents/code-reviewer.md
 
@@ -73,5 +71,6 @@ jobs:
             3. Apply the review checklist to modified files
             4. Provide feedback organized by severity (Critical, Warning, Suggestion)
           claude_args: |
+            --model claude-opus-4-5-20251101
             --max-turns 10
             --allowedTools "Read,Glob,Grep,Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Update from `@beta` to `@v1`
- Remove invalid `track_progress` input
- Move `model` to `claude_args` (correct location per v1 docs)

Fixes CI failures on PR reviews.