### PR TITLE
fix(ci): use pull_request_target for fork PR support

### DIFF
--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -1,7 +1,7 @@
 name: PR - Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
@@ -20,18 +20,19 @@ jobs:
   review:
     # Run on PR events, or on issue comments that mention @claude
     if: |
-      github.event_name == 'pull_request' ||
+      github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (PR event)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repository (issue_comment event)
         if: github.event_name == 'issue_comment'
@@ -50,7 +51,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
             echo "base_ref=${{ github.event.pull_request.base.ref }}" >> $GITHUB_OUTPUT
           else
             BASE_REF=$(gh pr view ${{ github.event.issue.number }} --json baseRefName -q '.baseRefName')


### PR DESCRIPTION
Fixes claude-code-action failing on fork PRs with "couldn't find remote ref" error.

Changes:
- `pull_request` → `pull_request_target` (runs in base repo context)
- Add `repository` to checkout step for fork PRs

Ref: https://github.com/anthropics/claude-code-action/issues/223