### PR TITLE
fix(ci): use Node 22 for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node for npm publish
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Release


### PR DESCRIPTION
## Summary
semantic-release 25.x requires Node ^22.14.0 || >= 24.10.0

Release workflow was failing with:
```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.6.
```

## Changes
- Update `node-version` from '20' to '22' in release.yml