### PR TITLE
fix: replace workspace:* with * for npm compatibility

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/sirsjg/flux",
   "dependencies": {},
   "devDependencies": {
-    "@flux/shared": "workspace:*",
+    "@flux/shared": "*",
     "@hono/node-server": "^1.13.7",
     "hono": "^4.6.12",
     "@types/node": "^22.10.5",


### PR DESCRIPTION
## Summary
Replace `workspace:*` with `*` for @flux/shared devDependency.

## Problem
npm doesn't support the `workspace:` protocol, causing semantic-release to fail:
```
npm error Unsupported URL Type "workspace:": workspace:*
```

## Solution
Since @flux/shared is a devDependency and the CLI is fully bundled, we can use `*` instead. The workspace protocol is only needed for local development (bun handles it).