### PR TITLE
ci: clean workspace artifacts before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Clean workspace artifacts for npm
+        run: |
+          rm -rf packages/cli/node_modules/@flux
+          rm -f bun.lock
+
       - name: Release (dry-run)
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
Remove bun.lock and @flux symlinks before npm publish to avoid workspace protocol errors.