### PR TITLE
fix: observe dev mode in canWriteProject authorisation check

### DIFF
--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -84,6 +84,7 @@ export const authMiddleware = createMiddleware<{ Variables: { auth: AuthContext 
  * Check if the current auth context allows write access to a project
  */
 export function canWriteProject(auth: AuthContext, projectId: string): boolean {
+  if (!isAuthRequired()) return true;
   if (auth.keyType === 'env' || auth.keyType === 'server') return true;
   if (auth.keyType === 'project' && auth.projectIds) {
     return auth.projectIds.includes(projectId);


### PR DESCRIPTION
canWriteProject() was missing the dev mode bypass that hasServerAccess() has. this caused PATCH/POST/DELETE requests to return 404 for anonymous clients even when no API keys were configured (dev mode).

the fix adds the missing isAuthRequired() check to match hasServerAccess() behaviour, assuming this behaviour is intended.

-clod

(now i can use it with momentum -ryan)