### PR TITLE
feat: adds agent team worker tracking to tasks and comments

### DIFF
--- a/packages/shared/src/client.ts
+++ b/packages/shared/src/client.ts
@@ -314,17 +314,22 @@ export async function isTaskBlocked(id: string): Promise<boolean> {
 export async function addTaskComment(
   taskId: string,
   body: string,
-  author: 'user' | 'mcp' = 'user'
+  author: 'user' | 'mcp' = 'user',
+  agentName?: string
 ): Promise<TaskComment | undefined> {
   if (serverUrl) {
     try {
-      return await http('POST', `/api/tasks/${taskId}/comments`, { body, author });
+      return await http('POST', `/api/tasks/${taskId}/comments`, {
+        body,
+        author,
+        ...(agentName ? { agent_name: agentName } : {}),
+      });
     } catch (e) {
       if (e instanceof FluxHttpError && e.isNotFound) return undefined;
       throw e;
     }
   }
-  return localAddTaskComment(taskId, body, author);
+  return localAddTaskComment(taskId, body, author, agentName);
 }
 
 export async function deleteTaskComment(taskId: string, commentId: string): Promise<boolean> {

--- a/packages/shared/src/store.ts
+++ b/packages/shared/src/store.ts
@@ -404,7 +404,8 @@ export function deleteTask(id: string): boolean {
 export function addTaskComment(
   taskId: string,
   body: string,
-  author: CommentAuthor
+  author: CommentAuthor,
+  agentName?: string
 ): TaskComment | undefined {
   const task = db.data.tasks.find(t => t.id === taskId);
   if (!task) return undefined;
@@ -412,6 +413,7 @@ export function addTaskComment(
     id: generateId(),
     body,
     author,
+    ...(agentName ? { agent_name: agentName } : {}),
     created_at: new Date().toISOString(),
   };
   if (!task.comments) task.comments = [];

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -27,6 +27,7 @@ export type TaskComment = {
   id: string;
   body: string;
   author: CommentAuthor;
+  agent_name?: string;
   created_at: string;
 };
 
@@ -53,6 +54,7 @@ export type Task = {
   acceptance_criteria?: string[]; // Observable behavioral outcomes for verification
   guardrails?: Guardrail[]; // Numbered instructions (higher = more critical)
   blob_ids?: string[]; // References to Blob.id
+  workers?: string[]; // Agent team members currently working on this task
   created_at?: string;
   updated_at?: string;
 };

--- a/packages/web/src/components/DraggableTaskCard.tsx
+++ b/packages/web/src/components/DraggableTaskCard.tsx
@@ -96,7 +96,12 @@ export function DraggableTaskCard({
             <progress class="progress w-8 flex-shrink-0" value={0} max={100} />
           )}
           {task.status === 'in_progress' && (
-            <progress class="progress progress-warning w-8 flex-shrink-0" />
+            <>
+              <progress class="progress progress-warning w-8 flex-shrink-0" />
+              {task.workers && task.workers.length > 0 && task.workers.map(name => (
+                <span key={name} class="badge badge-primary badge-xs flex-shrink-0">{name}</span>
+              ))}
+            </>
           )}
           {task.status === 'done' && (
             <progress class="progress progress-success w-8 flex-shrink-0" value={100} max={100} />
@@ -165,6 +170,9 @@ export function DraggableTaskCard({
             <>
               <progress class="progress progress-warning w-10" />
               <span class="badge badge-ghost badge-warning badge-xs">Agent working</span>
+              {task.workers && task.workers.map(name => (
+                <span key={name} class="badge badge-primary badge-xs">{name}</span>
+              ))}
             </>
           )}
           {task.status === 'done' && (

--- a/packages/web/src/components/TaskForm.tsx
+++ b/packages/web/src/components/TaskForm.tsx
@@ -605,6 +605,11 @@ export function TaskForm({
                               >
                                 {comment.author === "mcp" ? "MCP" : "User"}
                               </span>
+                              {comment.agent_name && (
+                                <span class="badge badge-primary badge-xs">
+                                  {comment.agent_name}
+                                </span>
+                              )}
                               {comment.created_at && (
                                 <span class="text-xs text-base-content/50">
                                   {new Date(


### PR DESCRIPTION
Enables Claude Code Agent Teams to report which teammates are working on Flux tasks. MCP tools accept an optional agent_name param that populates a workers[] array on in-progress tasks and agent_name on comments, rendered as badges on the Kanban board and in the task form.