### PR TITLE
feat(mcp): add get_task tool for fetching single task with full details

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -361,6 +361,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'get_task',
+        description: 'Get a single task with full details including comments',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            task_id: { type: 'string', description: 'Task ID' },
+          },
+          required: ['task_id'],
+        },
+      },
+      {
         name: 'create_task',
         description: 'Create a new task in a project. Use add_task_comment to add notes.',
         inputSchema: {
@@ -730,6 +741,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       return {
         content: [{ type: 'text', text: JSON.stringify(tasks, null, 2) }],
+      };
+    }
+
+    case 'get_task': {
+      const task = await getTask(args?.task_id as string);
+      if (!task) {
+        return { content: [{ type: 'text', text: 'Task not found' }], isError: true };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ...task, blocked: await isTaskBlocked(task.id) }, null, 2) }],
       };
     }
 


### PR DESCRIPTION
## Problem

As reported in #67, the `list_tasks` MCP response includes all task comments, causing responses to grow very large over time (222K+ characters reported). This can exceed LLM token limits.

## Solution

Adds a new `get_task` MCP tool that returns a single task by ID with all fields including comments and blocked status. This lets agents fetch detailed task info on demand rather than relying solely on `list_tasks`.

### New tool

- **`get_task`** — accepts `task_id` (required), returns the full task object with comments and blocked status.

### No breaking changes

`list_tasks` behavior is unchanged.

Closes #67