### PR TITLE
fix: move /api/tasks/ready route before /api/tasks/:id to prevent route capture

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -351,6 +351,15 @@ app.get('/api/projects/:projectId/tasks', (c) => {
   return c.json(tasks);
 });
 
+// Ready tasks (unblocked, not done, sorted by priority)
+// NOTE: Must be registered BEFORE /api/tasks/:id to avoid :id capturing "ready"
+app.get('/api/tasks/ready', (c) => {
+  const auth = c.get('auth');
+  const projectId = c.req.query('project_id');
+  const tasks = getReadyTasks(projectId).filter(t => canReadProject(auth, t.project_id));
+  return c.json(tasks);
+});
+
 app.get('/api/tasks/:id', (c) => {
   const auth = c.get('auth');
   const task = getTask(c.req.param('id'));
@@ -464,14 +473,6 @@ app.delete('/api/tasks/:id', (c) => {
   if (!success) return c.json({ error: 'Task not found' }, 404);
   triggerWebhooks('task.deleted', { task }, task.project_id);
   return c.json({ success: true });
-});
-
-// Ready tasks (unblocked, not done, sorted by priority)
-app.get('/api/tasks/ready', (c) => {
-  const auth = c.get('auth');
-  const projectId = c.req.query('project_id');
-  const tasks = getReadyTasks(projectId).filter(t => canReadProject(auth, t.project_id));
-  return c.json(tasks);
 });
 
 // Cleanup project (archive done tasks and/or delete empty epics)


### PR DESCRIPTION
## Bug

`GET /api/tasks/ready` was returning `{"error": "Task not found"}` instead of the list of ready tasks.

## Root Cause

Hono matched `/api/tasks/ready` against the `/api/tasks/:id` route (registered first), treating `"ready"` as a task ID. `getTask("ready")` found nothing and returned 404.

## Fix

Move the static `/api/tasks/ready` route **before** the parameterized `/api/tasks/:id` route so Hono matches the literal path first.

One file changed, no new dependencies, no API changes.