### PR TITLE
feat: make status and epic colors themeable via CSS variables

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -133,25 +133,36 @@ export type Status = 'planning' | 'todo' | 'in_progress' | 'done';
 
 export const STATUSES: Status[] = ['planning', 'todo', 'in_progress', 'done'];
 
-// Status display names and colors
+// Status display names and colors.
+//
+// Each colour is a CSS custom property with the previous hex as its fallback,
+// so appearance is unchanged unless someone defines the variable. These land in
+// the DOM as inline styles (`style={{ backgroundColor: config.color }}` in
+// Board.tsx), which a stylesheet cannot otherwise reach — so a custom theme can
+// restyle every daisyUI token and still be stuck with stock status dots. See #77.
 export const STATUS_CONFIG: Record<Status, { label: string; color: string }> = {
-  planning: { label: 'Planning', color: '#a855f7' },
-  todo: { label: 'To Do', color: '#6b7280' },
-  in_progress: { label: 'In Progress', color: '#3b82f6' },
-  done: { label: 'Done', color: '#22c55e' },
+  planning: { label: 'Planning', color: 'var(--flux-status-planning, #a855f7)' },
+  todo: { label: 'To Do', color: 'var(--flux-status-todo, #6b7280)' },
+  in_progress: { label: 'In Progress', color: 'var(--flux-status-in-progress, #3b82f6)' },
+  done: { label: 'Done', color: 'var(--flux-status-done, #22c55e)' },
 };
 
-// Epic colors palette
+// Epic colors palette. Same variable-with-fallback shape as STATUS_CONFIG, and
+// for the same reason — these reach the DOM as inline styles via getEpicColor().
 export const EPIC_COLORS = [
-  '#3b82f6', // blue
-  '#22c55e', // green
-  '#f59e0b', // orange/amber
-  '#8b5cf6', // purple
-  '#ef4444', // red
-  '#06b6d4', // cyan
-  '#ec4899', // pink
-  '#84cc16', // lime
+  'var(--flux-epic-1, #3b82f6)', // blue
+  'var(--flux-epic-2, #22c55e)', // green
+  'var(--flux-epic-3, #f59e0b)', // orange/amber
+  'var(--flux-epic-4, #8b5cf6)', // purple
+  'var(--flux-epic-5, #ef4444)', // red
+  'var(--flux-epic-6, #06b6d4)', // cyan
+  'var(--flux-epic-7, #ec4899)', // pink
+  'var(--flux-epic-8, #84cc16)', // lime
 ];
+
+// The "Unassigned" dot — the default for any task with no epic, so on a board
+// with no epics defined this is every card.
+export const EPIC_COLOR_UNASSIGNED = 'var(--flux-epic-unassigned, #9ca3af)';
 
 // ============ Webhook Types ============
 

--- a/packages/web/src/components/DraggableTaskCard.tsx
+++ b/packages/web/src/components/DraggableTaskCard.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownIcon, CheckCircleIcon, PaperClipIcon, ShieldCheckIcon } from '@heroicons/react/24/outline'
 import { useDraggable } from '@dnd-kit/core'
 import { CSS } from '@dnd-kit/utilities'
+import { EPIC_COLOR_UNASSIGNED } from '@flux/shared'
 import type { TaskWithBlocked } from '../stores'
 
 interface DraggableTaskCardProps {
@@ -14,7 +15,7 @@ interface DraggableTaskCardProps {
 
 export function DraggableTaskCard({
   task,
-  epicColor = '#9ca3af',
+  epicColor = EPIC_COLOR_UNASSIGNED,
   epicTitle = 'Unassigned',
   taskNumber,
   onClick,

--- a/packages/web/src/pages/Board.tsx
+++ b/packages/web/src/pages/Board.tsx
@@ -18,7 +18,7 @@ import {
   type TaskWithBlocked,
 } from "../stores";
 import type { Epic } from "@flux/shared";
-import { STATUSES, STATUS_CONFIG, EPIC_COLORS } from "@flux/shared";
+import { STATUSES, STATUS_CONFIG, EPIC_COLORS, EPIC_COLOR_UNASSIGNED } from "@flux/shared";
 import {
   TaskForm,
   EpicForm,
@@ -713,7 +713,7 @@ export function Board({ projectId }: BoardProps) {
                                 <DraggableTaskCard
                                   key={task.id}
                                   task={task}
-                                  epicColor="#9ca3af"
+                                  epicColor={EPIC_COLOR_UNASSIGNED}
                                   epicTitle="Unassigned"
                                   taskNumber={taskIndex + 1}
                                   onClick={() => openEditTask(task)}


### PR DESCRIPTION
Refs #77.

Makes the status and epic colors themeable, without changing appearance for
anyone who doesn't opt in.

### The problem

`STATUS_CONFIG`, `EPIC_COLORS` and the `#9ca3af` "Unassigned" default reach the
DOM as inline styles — `style={{ backgroundColor: config.color }}` in `Board.tsx`,
and the same via `epicColor` in `DraggableTaskCard.tsx`. An inline style beats any
selector on specificity, so a stylesheet can't reach them.

The practical effect: a custom theme can restyle every daisyUI token — canvas,
cards, buttons, borders — and still be left with stock status and epic dots. And
because the "Unassigned" color is the default for any task with no epic, a board
with no epics defined shows those stock dots on **every card**.

### The change

Each color becomes a CSS custom property with its current hex as the fallback:

```ts
planning: { label: 'Planning', color: 'var(--flux-status-planning, #a855f7)' },
```

Thirteen variables in total — four status, eight epic, one unassigned. A theme
defines whichever it wants; anyone who defines none sees exactly what they see
today.

`EPIC_COLOR_UNASSIGNED` is a new export. `#9ca3af` was previously a bare literal
duplicated in two places (a default parameter in `DraggableTaskCard` and an
inline prop in `Board`), so this also states it once.

### Deliberately not included

`PRIORITY_CONFIG.color` is untouched. It's never painted — the web package
doesn't import it, and the CLI destructures only `label` and `ansi` — so changing
it would widen the diff without enabling anything. Happy to add it if you'd
rather the three tables stay symmetrical.

### Verified

- `bun --filter @flux/shared build` then `bun run build` in `packages/web` — both
  clean, including `tsc -b`
- the built bundle carries all 13 `var()` forms with their original hexes
- the built stylesheet defines **none** of those variables, so every one resolves
  to its fallback — an unmodified build is visually identical

### Why this is worth having

I've been theming a board through the daisyUI token layer, which works well and
needs no changes to flux at all. These dots were the only thing out of reach. My
current workaround matches the CSSOM's serialization of the inline style:

```css
[style*="background-color: rgb(59, 130, 246)"] { background-color: … !important }
```

It's exact and it works, but it has to be re-applied after every build since a
gitignored `dist/` is the only writable surface. These variables delete that
whole layer — for any theme, not just mine.
